### PR TITLE
✨ feat: HttpClient 제작 및 기본 API 함수 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ yarn-error.log*
 
 # local env files
 .env*.local
+.env
 
 # vercel
 .vercel

--- a/lib/api/API_CONSTANTS.ts
+++ b/lib/api/API_CONSTANTS.ts
@@ -1,0 +1,64 @@
+import { Id, OAuthProvider } from '@ccc-types';
+import { ResponseCookie } from 'next/dist/compiled/@edge-runtime/cookies';
+
+export const ENDPOINTS = {
+  USER: {
+    ACTIONS: `/user`,
+    GET_HISTORY: `/user/history`,
+    POST_SEND_RESET_PASSWORD_EMAIL: `/user/send-reset-password-email`,
+    PATCH_RESET_PASSWORD: `/user/reset-password`,
+    PATCH_PASSWORD: `/user/password`,
+  },
+  TASKLIST: {
+    GROUP_ACTIONS: (groupId: Id, id: Id) =>
+      `/groups/${groupId}/task-lists/${id}`,
+    POST: (groupId: Id) => `/groups/${groupId}/task-lists`,
+    PATCH_ORDER: (groupId: Id, id: Id) =>
+      `/groups/${groupId}/task-lists/${id}/order`,
+  },
+  TASK: {
+    ACTIONS_ITEM: (groupId: Id, taskListId: Id, taskId: Id) =>
+      `/groups/${groupId}/task-lists/${taskListId}/tasks/${taskId}`,
+    ACTIONS: (groupId: Id, taskListId: Id) =>
+      `/groups/${groupId}/task-lists/${taskListId}/tasks`,
+    DELETE_ALL_TASKS: (groupId: Id, taskListId: Id, taskId: Id) =>
+      `/groups/${groupId}/task-lists/${taskListId}/tasks/${taskId}/all`,
+  },
+  OAUTH: {
+    POST_OAUTH_APPS: `/oauthApps`,
+  },
+  IMAGE: {
+    POST_IMAGE_UPLOAD: `/images/upload`,
+  },
+  GROUP: {
+    ACTIONS: (id: Id) => `/groups/${id}`,
+    POST: `/groups`,
+    MEMBER_ACTIONS: (id: Id, memberUserId: Id) =>
+      `/groups/${id}/member/${memberUserId}`,
+    MEMBER_POST: (id: Id) => `/groups/${id}/member`,
+    GET_GROUP_INVITATION: (id: Id) => `/groups/${id}/invitation`,
+    POST_GROUP_ACCEPT_INVITATION: `/groups/accept-invitation`,
+
+    GET_GROUP_TASKS: (id: Id) => `/groups/${id}/tasks`,
+  },
+  COMMENTS: {
+    ACTIONS: (taskId: Id) => `/tasks/${taskId}/comments`,
+    ITEM_ACTIONS: (taskId: Id, commentId: Id) =>
+      `/tasks/${taskId}/comments/${commentId}`,
+  },
+  AUTH: {
+    POST_SIGNUP: `/auth/signUp`,
+    POST_SIGNIN: `/auth/signIn`,
+    POST_REFRESH_TOKEN: `/auth/refresh-token`,
+    POST_SIGNIN_PROVIDER: (provider: OAuthProvider) =>
+      `/auth/signIn/${provider}`,
+  },
+};
+
+export const DEFAULT_TOKEN_OPTIONS: Partial<ResponseCookie> = {
+  httpOnly: true,
+  maxAge: 60 * 60, // 1 hour
+  path: '/',
+  secure: process.env.NODE_ENV === 'production',
+  sameSite: 'lax',
+};

--- a/lib/api/API_CONSTANTS.ts
+++ b/lib/api/API_CONSTANTS.ts
@@ -41,10 +41,10 @@ export const ENDPOINTS = {
 
     GET_GROUP_TASKS: (id: Id) => `/groups/${id}/tasks`,
   },
-  COMMENTS: {
-    ACTIONS: (taskId: Id) => `/tasks/${taskId}/comments`,
-    ITEM_ACTIONS: (taskId: Id, commentId: Id) =>
-      `/tasks/${taskId}/comments/${commentId}`,
+  COMMENT: {
+    TASK: (taskId: Id) => `/tasks/${taskId}/comments`,
+    ARTICLE: (articleId: Id) => `/articles/${articleId}/comments`,
+    ACTIONS: (commentId: Id) => `/comments/${commentId}`,
   },
   AUTH: {
     POST_SIGNUP: `/auth/signUp`,
@@ -52,6 +52,11 @@ export const ENDPOINTS = {
     POST_REFRESH_TOKEN: `/auth/refresh-token`,
     POST_SIGNIN_PROVIDER: (provider: OAuthProvider) =>
       `/auth/signIn/${provider}`,
+  },
+  ARTICLE: {
+    ACTIONS: `/articles`,
+    ACTIONS_ITEM: (articleId: Id) => `/articles/${articleId}`,
+    LIKE: (articleId: Id) => `/articles/${articleId}/like`,
   },
 };
 

--- a/lib/api/HttpClient/HttpClient.ts
+++ b/lib/api/HttpClient/HttpClient.ts
@@ -1,0 +1,113 @@
+import InterceptorManager from '@/lib/api/HttpClient/Interceptor';
+import { HttpClientConfig, mergeConfig } from '@/lib/api/HttpClient/utils';
+
+/**
+ * 에러는 { message , cause: { ok , status, statusText ... requestConfig} }
+ */
+export default class Client {
+  private defaults: HttpClientConfig;
+
+  public interceptors: {
+    request: InterceptorManager<any>;
+    response: InterceptorManager<any>;
+  };
+
+  constructor(instanceConfig: HttpClientConfig) {
+    this.defaults = instanceConfig;
+    this.interceptors = {
+      request: new InterceptorManager(),
+      response: new InterceptorManager(),
+    };
+  }
+
+  public async request(
+    configOrUrl: string | HttpClientConfig,
+    config?: HttpClientConfig
+  ): Promise<any> {
+    let finalConfig: HttpClientConfig;
+    if (typeof configOrUrl === 'string') {
+      finalConfig = mergeConfig(this.defaults, { url: configOrUrl, ...config });
+    } else {
+      finalConfig = mergeConfig(this.defaults, configOrUrl);
+    }
+
+    finalConfig.method = (finalConfig.method || 'get').toUpperCase();
+
+    const requestHeaders: { [key: string]: string } = {
+      ...this.defaults.headers,
+      ...finalConfig.headers,
+    };
+
+    const isFormData = finalConfig.data instanceof FormData;
+
+    if (
+      isFormData ||
+      requestHeaders['Content-Type'] === 'multipart/form-data'
+    ) {
+      delete requestHeaders['Content-Type'];
+    }
+    const requestBody = isFormData
+      ? finalConfig?.data
+      : JSON.stringify(finalConfig?.data) || undefined;
+
+    let requestOptions: RequestInit = {
+      method: finalConfig.method,
+      headers: requestHeaders,
+      credentials: finalConfig.withCredentials ? 'include' : 'same-origin',
+      body: requestBody,
+      ...finalConfig,
+    };
+
+    await Promise.all(
+      this.interceptors.request.handlers.map(async (handler) => {
+        if (!handler.runWhen || handler.runWhen(finalConfig)) {
+          requestOptions =
+            (await handler.fulfilled?.({
+              ...requestOptions,
+              ...finalConfig,
+            })) || requestOptions;
+        }
+      })
+    );
+
+    try {
+      const response = await fetch(
+        `${finalConfig.baseURL}${finalConfig.url}`,
+        requestOptions
+      );
+
+      if (!response.ok && response.status >= 400) {
+        const errorBody = JSON.parse(
+          await response.text().then((text) => text || '{}')
+        );
+
+        throw new Error(errorBody?.message ?? response.statusText, {
+          cause: { ...response, requestConfig: finalConfig },
+        });
+      }
+
+      let handledResponse = await response.json();
+
+      await Promise.all(
+        this.interceptors.response.handlers.map(async (handler) => {
+          if (!handler.runWhen || handler.runWhen(response)) {
+            handledResponse =
+              (await handler.fulfilled?.(response)) || handledResponse;
+          }
+        })
+      );
+
+      return handledResponse;
+    } catch (error) {
+      await Promise.all(
+        this.interceptors.response.handlers.map(async (handler) => {
+          if (handler.rejected) {
+            await handler.rejected(error);
+          }
+        })
+      );
+
+      throw new Error('unknownError', { cause: error });
+    }
+  }
+}

--- a/lib/api/HttpClient/Interceptor.ts
+++ b/lib/api/HttpClient/Interceptor.ts
@@ -1,0 +1,26 @@
+export default class InterceptorManager<T> {
+  public handlers: {
+    fulfilled?: ((value: T) => T | Promise<T>) | null | undefined;
+    rejected?: ((error: any) => any) | null | undefined;
+    synchronous: boolean;
+    runWhen: ((config: any) => boolean) | null;
+  }[] = [];
+
+  use(
+    fulfilled?: ((value: T) => T | Promise<T>) | null | undefined,
+    rejected?: ((error: any) => any) | null | undefined,
+    options?: { synchronous?: boolean; runWhen?: (config: any) => boolean }
+  ) {
+    this.handlers.push({
+      fulfilled,
+      rejected,
+      synchronous: options?.synchronous ?? false,
+      runWhen: options?.runWhen ?? null,
+    });
+    return this.handlers.length - 1;
+  }
+
+  forEach(callback: (handler: any) => void) {
+    this.handlers.forEach(callback);
+  }
+}

--- a/lib/api/HttpClient/index.ts
+++ b/lib/api/HttpClient/index.ts
@@ -1,7 +1,6 @@
-import CustomError from '@/lib/api/HttpClient/Error';
 import Client from '@/lib/api/HttpClient/HttpClient';
 import InterceptorManager from '@/lib/api/HttpClient/Interceptor';
 import { HttpClientConfig, mergeConfig } from '@/lib/api/HttpClient/utils';
 
-export { Client, CustomError, InterceptorManager, mergeConfig };
+export { Client, InterceptorManager, mergeConfig };
 export type { HttpClientConfig };

--- a/lib/api/HttpClient/index.ts
+++ b/lib/api/HttpClient/index.ts
@@ -1,0 +1,7 @@
+import CustomError from '@/lib/api/HttpClient/Error';
+import Client from '@/lib/api/HttpClient/HttpClient';
+import InterceptorManager from '@/lib/api/HttpClient/Interceptor';
+import { HttpClientConfig, mergeConfig } from '@/lib/api/HttpClient/utils';
+
+export { Client, CustomError, InterceptorManager, mergeConfig };
+export type { HttpClientConfig };

--- a/lib/api/HttpClient/utils.ts
+++ b/lib/api/HttpClient/utils.ts
@@ -1,0 +1,42 @@
+export interface HttpClientConfig {
+  baseURL?: string; // 기본 URL
+  headers?: { [key: string]: string }; // 요청 헤더
+  timeout?: number; // 타임아웃 설정 (밀리초 단위)
+  withCredentials?: boolean; // 크로스 사이트 요청에 자격 증명 포함 여부
+  method?: string; // method?: 'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH' | 'OPTIONS' | 'HEAD'; // HTTP 메소드
+  url?: string; // 요청 URL (baseURL과 결합됨)
+  data?: any; // 요청 본문 (POST, PUT, PATCH 등에서 사용)
+  referrer?: string; // 요청의 출처
+  referrerPolicy?: ReferrerPolicy; // 출처 정책
+  mode?: RequestMode; // 요청 모드 (cors, no-cors, same-origin 등)
+  credentials?: RequestCredentials; // 자격 증명 옵션 (same-origin, include, omit)
+  cache?: RequestCache; // 캐시 옵션 (default, no-store, reload, no-cache, force-cache, only-if-cached)
+  redirect?: RequestRedirect; // 리디렉션 옵션 (follow, manual, error)
+  integrity?: string; // 서브 리소스 무결성 (SRI)
+  keepalive?: boolean; // Keep-alive 옵션
+  signal?: AbortSignal; // 요청 취소 신호
+  next?: {
+    revalidate?: false | number; // 리소스의 캐시 수명(초)을 설정
+    tag?: string[]; // 리소스의 캐시 태그를 설정
+  };
+}
+
+export function mergeConfig(
+  defaults: HttpClientConfig,
+  config: HttpClientConfig
+): HttpClientConfig {
+  const mergedHeaders = {
+    ...defaults.headers,
+    ...config.headers,
+  };
+
+  if (config?.headers?.['Content-Type'] === 'multipart/form-data') {
+    delete mergedHeaders['Content-Type'];
+  }
+
+  return {
+    ...defaults,
+    ...config,
+    headers: mergedHeaders,
+  };
+}

--- a/lib/api/article.ts
+++ b/lib/api/article.ts
@@ -1,0 +1,86 @@
+'use server';
+
+import { ENDPOINTS } from '@/lib/api/API_CONSTANTS';
+import client from '@/lib/api/client/server';
+import { Article, ArticleDetail, Id } from '@ccc-types';
+
+type CreateArticleBody = Pick<Article, 'image' | 'content' | 'title'>;
+type UpdateArticleBody = Partial<CreateArticleBody>;
+
+export async function createArticle(data: CreateArticleBody): Promise<Article> {
+  const { data: response, error } = await client<Article>(
+    ENDPOINTS.ARTICLE.ACTIONS,
+    {
+      method: 'post',
+      data,
+    }
+  );
+  if (error) {
+    throw new Error(`게시글을 생성하는 중 중 에러가 발생했습니다`, {
+      cause: error,
+    });
+  }
+  return response;
+}
+
+export async function updateArticle(
+  articleId: Id,
+  data: UpdateArticleBody
+): Promise<ArticleDetail> {
+  const { data: response, error } = await client<ArticleDetail>(
+    ENDPOINTS.ARTICLE.ACTIONS_ITEM(articleId),
+    {
+      method: 'patch',
+      data,
+    }
+  );
+  if (error) {
+    throw new Error(`게시글을 수정하는 중 에러가 발생했습니다`, {
+      cause: error,
+    });
+  }
+  return response;
+}
+
+export async function deleteArticle(articleId: Id): Promise<{ id: Id }> {
+  const { data, error } = await client<{ id: Id }>(
+    ENDPOINTS.ARTICLE.ACTIONS_ITEM(articleId),
+    {
+      method: 'delete',
+    }
+  );
+  if (error) {
+    throw new Error(`게시글을 삭제하는 중 에러가 발생했습니다.`, {
+      cause: error,
+    });
+  }
+  return data;
+}
+
+export async function likeArticle(articleId: Id): Promise<ArticleDetail> {
+  const { data: response, error } = await client<ArticleDetail>(
+    ENDPOINTS.ARTICLE.LIKE(articleId),
+    {
+      method: 'post',
+    }
+  );
+  if (error) {
+    throw new Error(`게시글 좋아요 중 에러가 발생했습니다`, { cause: error });
+  }
+  return response;
+}
+
+export async function unlikeArticle(articleId: Id): Promise<ArticleDetail> {
+  const { data: response, error } = await client<ArticleDetail>(
+    ENDPOINTS.ARTICLE.LIKE(articleId),
+    {
+      method: 'delete',
+    }
+  );
+  if (error) {
+    throw new Error(`게시글 좋아요 삭제 중 에러가 발생했습니다`, {
+      cause: error,
+    });
+  }
+  return response;
+}

--- a/lib/api/auth.ts
+++ b/lib/api/auth.ts
@@ -1,0 +1,138 @@
+'use server';
+
+import { DEFAULT_TOKEN_OPTIONS, ENDPOINTS } from '@/lib/api/API_CONSTANTS';
+import client from '@/lib/api/client/server';
+import {
+  Id,
+  OAuthProvider,
+  OAuthToken,
+  Password,
+  UrlType,
+  User,
+} from '@ccc-types';
+import { jwtDecode } from 'jwt-decode';
+import { revalidatePath } from 'next/cache';
+import { cookies } from 'next/headers';
+import { redirect } from 'next/navigation';
+
+type PasswordAuthentication = {
+  passwordConfirmation: Password;
+  password: Password;
+};
+
+type SignUpRequestBody = Pick<User, 'image' | 'nickname' | 'email'> &
+  PasswordAuthentication;
+
+type SignInRequestBody = Pick<SignUpRequestBody, 'email' | 'password'>;
+interface SignInWithOAuthRequestBody {
+  state: string; // code를 얻을 때 사용하였던 state 값
+  redirectUri: UrlType; // example: http://localhost:3000/OAuth/kakao
+  token: OAuthToken;
+}
+interface AuthResponse {
+  refreshToken: string;
+  accessToken: string;
+  user: User;
+}
+
+function setTokenAndRedirection(accessToken: string, refreshToken: string) {
+  cookies().set('accessToken', accessToken, DEFAULT_TOKEN_OPTIONS);
+  cookies().set('refreshToken', refreshToken, {
+    ...DEFAULT_TOKEN_OPTIONS,
+    maxAge: 60 * 60 * 24 * 7,
+  });
+  revalidatePath('/', 'layout');
+  redirect('/');
+}
+
+export async function signup(data: SignUpRequestBody): Promise<void> {
+  const { data: response, error } = await client<AuthResponse>(
+    ENDPOINTS.AUTH.POST_SIGNUP,
+    {
+      method: 'post',
+      data,
+    }
+  );
+  if (error) {
+    throw new Error('회원가입에 실패했습니다', { cause: error });
+  }
+  setTokenAndRedirection(response.accessToken, response.refreshToken);
+}
+
+export async function login(data: SignInRequestBody): Promise<void> {
+  const { data: response, error } = await client<AuthResponse>(
+    ENDPOINTS.AUTH.POST_SIGNIN,
+    {
+      method: 'post',
+      data,
+    }
+  );
+  if (error) {
+    throw new Error('로그인에 실패했습니다', { cause: error });
+  }
+  setTokenAndRedirection(response.accessToken, response.refreshToken);
+}
+
+// 가입되어있지 않을 경우엔 가입됩니다.
+export async function loginWithOAuth(
+  provider: OAuthProvider,
+  data: SignInWithOAuthRequestBody
+): Promise<void> {
+  const { data: response, error } = await client<AuthResponse>(
+    ENDPOINTS.AUTH.POST_SIGNIN_PROVIDER(provider),
+    {
+      method: 'post',
+      data,
+    }
+  );
+  if (error) {
+    throw new Error('간편로그인에 실패했습니다', { cause: error });
+  }
+  setTokenAndRedirection(response.accessToken, response.refreshToken);
+}
+
+export async function logout() {
+  cookies().set('accessToken', '', { maxAge: -1, path: '/' });
+  cookies().set('refreshToken', '', { maxAge: -1, path: '/' });
+  redirect('/');
+}
+
+/*
+------------------ 토큰 관련  ------------------  
+*/
+
+type UserJWTDecode = {
+  exp: string;
+  iat: string;
+  id: Id;
+  iss: string;
+  scope: string;
+  teamId: string;
+};
+
+export async function checkAccessToken(accessToken: string) {
+  try {
+    const decodedToken: UserJWTDecode = jwtDecode(accessToken);
+    const isValid = decodedToken.iss === 'sp-coworkers';
+    const isExpired = Number(decodedToken.exp) * 1000 < new Date().getTime();
+    return !isExpired && isValid;
+  } catch (error) {
+    console.error('액세스 토큰 검사 중 오류 발생:', error);
+    return false;
+  }
+}
+
+export async function updateAccessToken(refreshToken: string) {
+  const { data, error } = await client<{ accessToken: string }>(
+    ENDPOINTS.AUTH.POST_REFRESH_TOKEN,
+    {
+      method: 'post',
+      data: { refreshToken },
+    }
+  );
+  if (error) {
+    throw new Error('토큰 갱신에 실패했습니다', { cause: error });
+  }
+  const newAccessToken = data.accessToken;
+  return newAccessToken;
+}

--- a/lib/api/client/client.ts
+++ b/lib/api/client/client.ts
@@ -1,0 +1,19 @@
+import { Client, HttpClientConfig } from '@/lib/api/HttpClient';
+
+const clientInstance = new Client({
+  baseURL: process.env.NEXT_PUBLIC_PROXY_URL,
+  headers: { 'Content-Type': 'application/json' },
+  timeout: 5000,
+  withCredentials: true,
+});
+
+const client = async <T = unknown>(url: string, options: HttpClientConfig) => {
+  try {
+    const response: T = await clientInstance.request(url, options);
+    return { data: response };
+  } catch (error) {
+    return { error: error as Error };
+  }
+};
+
+export default client;

--- a/lib/api/client/server.ts
+++ b/lib/api/client/server.ts
@@ -1,0 +1,40 @@
+'use server';
+
+import { Client, HttpClientConfig } from '@/lib/api/HttpClient';
+import Error from 'next/error';
+import { cookies } from 'next/headers';
+
+/* eslint-disable no-underscore-dangle, @typescript-eslint/return-await */
+
+const BASE_URL =
+  process.env.NODE_ENV === 'production'
+    ? process.env.NEXT_PUBLIC_APP_BASE_URL || ''
+    : 'http://localhost:3000';
+
+const serverClient = new Client({
+  baseURL: BASE_URL + process.env.NEXT_PUBLIC_PROXY_URL,
+  headers: { 'Content-Type': 'application/json' },
+  timeout: 5000,
+  withCredentials: true,
+});
+
+serverClient.interceptors.request.use((config) => {
+  const requestConfig = config;
+  const cookieStore = cookies();
+  const decodedCookie = decodeURIComponent(cookieStore.toString());
+
+  requestConfig.headers.Cookie = decodedCookie || '';
+
+  return requestConfig;
+});
+
+const client = async <T = unknown>(url: string, options: HttpClientConfig) => {
+  try {
+    const response: T = await serverClient.request(url, options);
+    return { data: response };
+  } catch (error) {
+    return { error: error as Error };
+  }
+};
+
+export default client;

--- a/lib/api/comment.ts
+++ b/lib/api/comment.ts
@@ -1,0 +1,50 @@
+'use server';
+
+import { ENDPOINTS } from '@/lib/api/API_CONSTANTS';
+import client from '@/lib/api/client/server';
+import { Id } from '@ccc-types';
+
+export async function postComment(
+  taskId: Id,
+  comment: string
+): Promise<Omit<Comment, 'user'>> {
+  const { data, error } = await client<Omit<Comment, 'user'>>(
+    ENDPOINTS.COMMENT.ACTIONS(taskId),
+    {
+      method: 'post',
+      data: {
+        content: comment,
+      },
+    }
+  );
+  if (error) {
+    throw new Error('메세지 생성 중 에러가 발생했습니다', { cause: error });
+  }
+  return data;
+}
+
+export async function updateComment(
+  commentId: Id,
+  comment: string
+): Promise<boolean> {
+  const { error } = await client<void>(ENDPOINTS.COMMENT.ACTIONS(commentId), {
+    method: 'patch',
+    data: {
+      content: comment,
+    },
+  });
+  if (error) {
+    throw new Error('메세지 수정 중 에러가 발생했습니다.', { cause: error });
+  }
+  return true;
+}
+
+export async function deleteComment(commentId: Id): Promise<boolean> {
+  const { error } = await client<void>(ENDPOINTS.COMMENT.ACTIONS(commentId), {
+    method: 'delete',
+  });
+  if (error) {
+    throw new Error('메세지 삭제 중 에러가 발생했습니다.', { cause: error });
+  }
+  return true;
+}

--- a/lib/api/common.ts
+++ b/lib/api/common.ts
@@ -1,0 +1,32 @@
+'use client';
+
+import { ENDPOINTS } from '@/lib/api/API_CONSTANTS';
+import client from '@/lib/api/client/client';
+import { UrlType } from '@ccc-types';
+
+/**
+ * 이미지 파일, 최대 용량은 10MB입니다.
+ * @param imageFile
+ *
+ * @returns imageString($binary)
+ */
+
+async function uploadImage(imageFile: any): Promise<UrlType> {
+  const formData = new FormData();
+  formData.append('image', imageFile);
+
+  const { data, error } = await client<{ url: UrlType }>(
+    ENDPOINTS.IMAGE.POST_IMAGE_UPLOAD,
+    {
+      method: 'post',
+      data: formData,
+      headers: { 'Content-Type': 'multipart/form-data' },
+    }
+  );
+  if (error) {
+    throw new Error('이미지 업로드에 실패했습니다', { cause: error });
+  }
+  return data.url;
+}
+
+export default uploadImage;

--- a/lib/api/fetchAPI.ts
+++ b/lib/api/fetchAPI.ts
@@ -1,0 +1,184 @@
+import { ENDPOINTS } from '@/lib/api/API_CONSTANTS';
+import client from '@/lib/api/client/server';
+import {
+  Article,
+  ArticleDetail,
+  CursorBasedPagination,
+  Group,
+  GroupTask,
+  Id,
+  OffsetBasedPagination,
+  Task,
+  User,
+} from '@ccc-types';
+
+async function getUser(): Promise<User> {
+  const { data, error } = await client<User>(ENDPOINTS.USER.ACTIONS, {
+    method: 'get',
+  });
+  if (error) {
+    throw new Error('유저의 정보를 가져오는 중 에러가 발생했습니다.', {
+      cause: error,
+    });
+  }
+  return data;
+}
+
+async function getUserHistory(): Promise<{ taskDone: Task[] }> {
+  const { data, error } = await client<{ taskDone: Task[] }>(
+    ENDPOINTS.USER.GET_HISTORY,
+    {
+      method: 'get',
+    }
+  );
+  if (error) {
+    throw new Error('유저의 히스토리를 가져오는 중 에러가 발생했습니다.', {
+      cause: error,
+    });
+  }
+  return data;
+}
+
+async function getTaskList(groupId: Id, taskListId: Id): Promise<GroupTask[]> {
+  const { data, error } = await client<GroupTask[]>(
+    ENDPOINTS.TASKLIST.GROUP_ACTIONS(groupId, taskListId),
+    {
+      method: 'get',
+      // NOTE 쿼리로 date를 받음, 사용하실때 수정해서 사용해주세요!
+    }
+  );
+  if (error) {
+    throw new Error(`TaskList${taskListId}를 가져오는 중 에러가 발생했습니다`, {
+      cause: error,
+    });
+  }
+  return data;
+}
+
+// 특정 일자, 특정 할일 리스트의 할일 리스트
+async function getGroupSpecificTasks(groupId: Id): Promise<Task[]> {
+  const { data, error } = await client<Task[]>(
+    ENDPOINTS.GROUP.GET_GROUP_TASKS(groupId),
+    {
+      method: 'get',
+      // NOTE 쿼리로 date를 받음, 사용하실때 수정해서 사용해주세요!
+    }
+  );
+  if (error) {
+    throw new Error('그룹 tasks를 가져오는 중 에러가 발생했습니다', {
+      cause: error,
+    });
+  }
+  return data;
+}
+
+async function getTask(groupId: Id, taskListId: Id): Promise<Task[]> {
+  const { data, error } = await client<Task[]>(
+    ENDPOINTS.TASK.ACTIONS(groupId, taskListId),
+    {
+      method: 'get',
+      // NOTE 쿼리로 date를 받음, 사용하실때 수정해서 사용해주세요!
+    }
+  );
+  if (error) {
+    throw new Error(
+      `TaskList${taskListId}의 tasks를 가져오는 중 에러가 발생했습니다`,
+      {
+        cause: error,
+      }
+    );
+  }
+  return data;
+}
+
+async function getGroup(groupId: Id): Promise<Group> {
+  const { data, error } = await client<Group>(
+    ENDPOINTS.GROUP.ACTIONS(groupId),
+    {
+      method: 'get',
+    }
+  );
+  if (error) {
+    throw new Error('그룹 정보를 가져오는 중 에러가 발생했습니다', {
+      cause: error,
+    });
+  }
+  return data;
+}
+
+async function getComments(taskId: Id): Promise<Comment[]> {
+  const { data, error } = await client<Comment[]>(
+    ENDPOINTS.COMMENT.ACTIONS(taskId),
+    {
+      method: 'get',
+    }
+  );
+  if (error) {
+    throw new Error('댓글을 가져오는데 실패했습니다', {
+      cause: error,
+    });
+  }
+  return data;
+}
+
+async function getArticles(): Promise<OffsetBasedPagination<Article>> {
+  const { data, error } = await client<OffsetBasedPagination<Article>>(
+    ENDPOINTS.ARTICLE.ACTIONS,
+    {
+      method: 'get',
+    }
+  );
+  if (error) {
+    throw new Error('게시글 목록을 가져오는데 실패했습니다', {
+      cause: error,
+    });
+  }
+  return data;
+}
+
+async function getArticle(articleID: Id): Promise<ArticleDetail> {
+  const { data, error } = await client<ArticleDetail>(
+    ENDPOINTS.ARTICLE.ACTIONS_ITEM(articleID),
+    {
+      method: 'get',
+    }
+  );
+  if (error) {
+    throw new Error('게시글 정보를 가져오는데 실패했습니다', {
+      cause: error,
+    });
+  }
+  return data;
+}
+
+async function getArticleComments(
+  articleID: Id
+): Promise<CursorBasedPagination<Comment>> {
+  const { data, error } = await client<CursorBasedPagination<Comment>>(
+    ENDPOINTS.COMMENT.ARTICLE(articleID),
+    {
+      method: 'get',
+    }
+  );
+  if (error) {
+    throw new Error('게시글 댓글 목록을 가져오는데 실패했습니다', {
+      cause: error,
+    });
+  }
+  return data;
+}
+
+const fetchAPI = {
+  User: getUser,
+  UserHistory: getUserHistory,
+  Group: getGroup,
+  GroupSpecificTasks: getGroupSpecificTasks,
+  Task: getTask,
+  TaskList: getTaskList,
+  Comments: getComments,
+  Articles: getArticles,
+  Article: getArticle,
+  ArticleComments: getArticleComments,
+};
+
+export default fetchAPI;

--- a/lib/api/group.ts
+++ b/lib/api/group.ts
@@ -1,0 +1,110 @@
+'use server';
+
+import { ENDPOINTS } from '@/lib/api/API_CONSTANTS';
+import client from '@/lib/api/client/server';
+import { Group, Id, Member } from '@ccc-types';
+
+export async function createGroup(
+  data: Partial<Pick<Group, 'image' | 'name'>>
+): Promise<Omit<Group, 'members' | 'taskLists'>> {
+  const { data: response, error } = await client<
+    Omit<Group, 'members' | 'taskLists'>
+  >(ENDPOINTS.GROUP.POST, {
+    method: 'post',
+    data,
+  });
+  if (error) {
+    throw new Error('그룹 생성 중 에러가 발생했습니다.', { cause: error });
+  }
+  return response;
+}
+
+export async function updateGroup(
+  groupId: Id,
+  data: Partial<Pick<Group, 'image' | 'name'>>
+): Promise<Omit<Group, 'members' | 'taskLists'>> {
+  const { data: response, error } = await client<
+    Omit<Group, 'members' | 'taskLists'>
+  >(ENDPOINTS.GROUP.ACTIONS(groupId), {
+    method: 'patch',
+    data,
+  });
+  if (error) {
+    throw new Error('그룹 업데이트 중 에러가 발생했습니다.', { cause: error });
+  }
+  return response;
+}
+
+export async function deleteGroup(groupId: Id) {
+  const { error } = await client<void>(ENDPOINTS.GROUP.ACTIONS(groupId), {
+    method: 'delete',
+  });
+  if (error) {
+    throw new Error('그룹 삭제 중 에러가 발생했습니다.', { cause: error });
+  }
+  return true;
+}
+
+export async function getMember(groupId: Id, memberId: Id): Promise<Member> {
+  const { data, error } = await client<Member>(
+    ENDPOINTS.GROUP.MEMBER_ACTIONS(groupId, memberId),
+    {
+      method: 'get',
+    }
+  );
+  if (error) {
+    throw new Error('멤버 정보를 가져오는 중 에러가 발생했습니다.', {
+      cause: error,
+    });
+  }
+  return data;
+}
+
+// 초대 링크없이 그룹에 유저를 추가
+export async function createMember(groupId: Id, data: { userId: string }) {
+  const { error } = await client<void>(ENDPOINTS.GROUP.MEMBER_POST(groupId), {
+    method: 'post',
+    data,
+  });
+  if (error) {
+    throw new Error('멤버 정보 생성 중 에러가 발생했습니다.', { cause: error });
+  }
+  return true;
+}
+
+// 초대 링크용 토큰 생성
+// 초대 링크에 토큰을 포함시켜서, 초대 링크를 받은 사용자가 접속시, 토큰을 사용해서 초대를 수락하여 스스로를 그룹에 포함시키게 됨.
+export async function createTokenForMemberInvitation(
+  groupId: Id
+): Promise<string> {
+  const { data, error } = await client<string>(
+    ENDPOINTS.GROUP.GET_GROUP_INVITATION(groupId),
+    {
+      method: 'get',
+    }
+  );
+  if (error) {
+    throw new Error('멤버 초대 토큰 생성 중 에러가 발생했습니다.', {
+      cause: error,
+    });
+  }
+  return data;
+}
+
+// GET {id}/invitation으로 생성한 토큰으로, 초대를 수락하는 엔드포인트
+export async function inviteMemberViaLink(userId: Id, token: string) {
+  const { error } = await client<void>(
+    ENDPOINTS.GROUP.POST_GROUP_ACCEPT_INVITATION,
+    {
+      method: 'post',
+      data: {
+        userId,
+        token,
+      },
+    }
+  );
+  if (error) {
+    throw new Error('초대 수락 중 에러가 발생했습니다.', { cause: error });
+  }
+  return true;
+}

--- a/lib/api/oAuth.ts
+++ b/lib/api/oAuth.ts
@@ -1,0 +1,31 @@
+import { ENDPOINTS } from '@/lib/api/API_CONSTANTS';
+import client from '@/lib/api/client/server';
+import { AppSecret, OAuthApp, OAuthProvider, UrlType } from '@ccc-types';
+
+// 간편로그인 등록/수정
+// Google, Kakao 간편 로그인을 위한 App 을 등록하거나 수정합니다.
+// 이미 등록된 앱이 있을 경우 덮어씌워집니다.
+
+export interface OAuthAppUpsertRequestBody {
+  appSecret?: AppSecret | null; // Google, KaKao 둘 다 필요하지 않음
+  appKey: UrlType; // Google: "클라이언트 id", Kakao: "REST API 키"
+  provider: OAuthProvider;
+}
+
+export async function oAuth(
+  data: OAuthAppUpsertRequestBody
+): Promise<OAuthApp> {
+  const { data: response, error } = await client<OAuthApp>(
+    ENDPOINTS.OAUTH.POST_OAUTH_APPS,
+    {
+      method: 'post',
+      data,
+    }
+  );
+  if (error) {
+    throw new Error('간편로그인 등록/수정 중 에러가 발생했습니다.', {
+      cause: error,
+    });
+  }
+  return response;
+}

--- a/lib/api/task.ts
+++ b/lib/api/task.ts
@@ -1,0 +1,97 @@
+'use server';
+
+import { ENDPOINTS } from '@/lib/api/API_CONSTANTS';
+import client from '@/lib/api/client/server';
+import { GroupTask, Id, Task } from '@ccc-types';
+
+export async function createTask(
+  groupId: Id,
+  taskListId: Id,
+  data: Partial<
+    Pick<
+      GroupTask,
+      'name' | 'description' | 'displayIndex' | 'frequencyType' | 'monthDay'
+    >
+  >
+): Promise<GroupTask> {
+  const { data: response, error } = await client<GroupTask>(
+    ENDPOINTS.TASK.ACTIONS(groupId, taskListId),
+    {
+      method: 'post',
+      data,
+    }
+  );
+  if (error) {
+    throw new Error(
+      `TaskList${taskListId}의 tasks를 생성하는 중 중 에러가 발생했습니다`,
+      { cause: error }
+    );
+  }
+  return response;
+}
+
+export async function updateTask(
+  groupId: Id,
+  taskListId: Id,
+  taskId: Id,
+  data: Pick<Task, 'name' | 'description'> & {
+    done: boolean;
+    displayIndex?: number;
+  }
+): Promise<Task> {
+  const { data: response, error } = await client<Task>(
+    ENDPOINTS.TASK.ACTIONS_ITEM(groupId, taskListId, taskId),
+    {
+      method: 'patch',
+      data,
+    }
+  );
+  if (error) {
+    throw new Error(
+      `TaskList${taskListId}의 tasks를 수정하는 중 에러가 발생했습니다`,
+      { cause: error }
+    );
+  }
+  return response;
+}
+
+export async function deleteTask(
+  groupId: Id,
+  taskListId: Id,
+  taskId: Id
+): Promise<boolean> {
+  const { error } = await client<void>(
+    ENDPOINTS.TASK.ACTIONS_ITEM(groupId, taskListId, taskId),
+    {
+      method: 'delete',
+    }
+  );
+  if (error) {
+    throw new Error(
+      `TaskList${taskListId}의 tasks를 삭제하는 중 에러가 발생했습니다.`,
+      { cause: error }
+    );
+  }
+  return true;
+}
+
+// 반복할일 삭제
+export async function deleteTaskAll(
+  groupId: Id,
+  taskListId: Id,
+  taskId: Id
+): Promise<boolean> {
+  const { error } = await client<void>(
+    ENDPOINTS.TASK.DELETE_ALL_TASKS(groupId, taskListId, taskId),
+    {
+      method: 'delete',
+    }
+  );
+  if (error) {
+    throw new Error(
+      `TaskList${taskListId}의 tasks를 반복 삭제하는 중 에러가 발생했습니다.`,
+      { cause: error }
+    );
+  }
+  return true;
+}

--- a/lib/api/taskList.ts
+++ b/lib/api/taskList.ts
@@ -1,0 +1,86 @@
+'use server';
+
+import { ENDPOINTS } from '@/lib/api/API_CONSTANTS';
+import client from '@/lib/api/client/server';
+import { GroupTask, Id } from '@ccc-types';
+
+export async function createTaskList(
+  groupId: Id,
+  data: { name: string }
+): Promise<GroupTask> {
+  const { data: response, error } = await client<GroupTask>(
+    ENDPOINTS.TASKLIST.POST(groupId),
+    {
+      method: 'post',
+      data,
+    }
+  );
+  if (error) {
+    throw new Error(`TaskList를 생성하는 중 중 에러가 발생했습니다`, {
+      cause: error,
+    });
+  }
+  return response;
+}
+
+export async function updateTaskList(
+  groupId: Id,
+  taskListId: Id,
+  data: { name: string }
+): Promise<GroupTask> {
+  const { data: response, error } = await client<GroupTask>(
+    ENDPOINTS.TASKLIST.GROUP_ACTIONS(groupId, taskListId),
+    {
+      method: 'patch',
+      data,
+    }
+  );
+  if (error) {
+    throw new Error(`TaskList${taskListId}를 수정하는 중 에러가 발생했습니다`, {
+      cause: error,
+    });
+  }
+  return response;
+}
+
+export async function deleteTask(
+  groupId: Id,
+  taskListId: Id
+): Promise<boolean> {
+  const { error } = await client<void>(
+    ENDPOINTS.TASKLIST.GROUP_ACTIONS(groupId, taskListId),
+    {
+      method: 'delete',
+    }
+  );
+  if (error) {
+    throw new Error(`TaskList${taskListId}를 삭제하는 중 에러가 발생했습니다`, {
+      cause: error,
+    });
+  }
+  return true;
+}
+
+// 할일 목록의 순서를 변경합니다.
+// taskList의 displayIndex를 변경합니다. 해당 taskList가 기존 displayIndex를 버리고 넘어가면서,
+// 그 빈 displayIndex는 "한 자리씩 당겨지는 식"으로 변경됩니다. [1,2,3,4] => (3을 0 인덱스로) => [3,1,2,4] => (4를 1 인덱스로) => [3,4,1,2]
+export async function reorderTaskList(
+  groupId: Id,
+  taskListId: Id,
+  data: { displayIndex: number }
+): Promise<boolean> {
+  const { error } = await client<void>(
+    ENDPOINTS.TASKLIST.PATCH_ORDER(groupId, taskListId),
+    {
+      method: 'patch',
+      data,
+    }
+  );
+  if (error) {
+    throw new Error(
+      `TaskList${taskListId}의 순서를 변경하는 중 에러가 발생했습니다`,
+      { cause: error }
+    );
+  }
+  return true;
+}

--- a/lib/api/user.ts
+++ b/lib/api/user.ts
@@ -1,0 +1,111 @@
+'use server';
+
+import { ENDPOINTS } from '@/lib/api/API_CONSTANTS';
+import client from '@/lib/api/client/server';
+import { Email, Nickname, Password, UrlType } from '@ccc-types';
+import { revalidatePath } from 'next/cache';
+import { redirect } from 'next/navigation';
+
+export async function updateUser(user: {
+  nickname?: Nickname;
+  image?: UrlType;
+}): Promise<{ message: string }> {
+  const { error } = await client<{ message: string }>(ENDPOINTS.USER.ACTIONS, {
+    method: 'patch',
+    data: user,
+  });
+  if (error) {
+    throw new Error('유저 정보를 업데이트 하는 중 에러가 발생했습니다.', {
+      cause: error,
+    });
+  }
+
+  revalidatePath('/', 'layout');
+  redirect('/');
+}
+
+export async function deleteUser(): Promise<boolean> {
+  const { error } = await client<void>(ENDPOINTS.USER.ACTIONS, {
+    method: 'delete',
+  });
+  if (error) {
+    throw new Error('유저 삭제에 실패했습니다.', { cause: error });
+  }
+  return true;
+}
+
+type PasswordAuthentication = {
+  passwordConfirmation: Password;
+  password: Password;
+};
+
+type SendResetPasswordEmailRequestBody = {
+  // 비밀번호 재설정 이메일 전송
+  // {redirectUrl}/reset-password?token=${token}로 이동할 수 있는 링크를 이메일로 전송합니다.
+  // e.g. "https://coworkers.vercel.app/reset-password?token=1234567890"
+  email: Email;
+  redirectUrl: UrlType;
+};
+
+type ResetPasswordRequestBody = PasswordAuthentication & {
+  token: string; // POST user/send-reset-password-email 요청으로 발송한 메일의 링크에 담긴 토큰
+};
+
+type PatchPasswordRequestBody = PasswordAuthentication;
+
+export async function sendResetPasswordEmail(
+  data: SendResetPasswordEmailRequestBody
+): Promise<{ message: string }> {
+  const { data: response, error } = await client<{ message: string }>(
+    ENDPOINTS.USER.POST_SEND_RESET_PASSWORD_EMAIL,
+    {
+      method: 'post',
+      data,
+    }
+  );
+  if (error) {
+    throw new Error('비밀번호 재설정 메일 전송에 실패했습니다', {
+      cause: error,
+    });
+  }
+  return response;
+}
+
+// 비밀번호 재설정 이메일 전송
+// {redirectUrl}/reset-password?token=${token}로 이동할 수 있는 링크를 이메일로 전송합니다.
+// e.g. "https://coworkers.vercel.app/reset-password?token=1234567890"
+
+// 비밀번호 재설정 요청: 사용자가 비밀번호 재설정을 요청하면, 서버는 유효한 token을 생성하고 이를 포함한 링크를 이메일로 전송합니다.
+// 링크 클릭: 사용자가 이메일 링크를 클릭하면 서버는 token을 검증하고, 사용자에게 비밀번호 재설정 페이지를 제공하거나 로그인 페이지로 리디렉션합니다.
+// 세션 생성: 서버는 검증된 token을 바탕으로 사용자의 세션을 생성하고, 비밀번호 재설정 폼을 사용자에게 보여줍니다.
+export async function resetPassword(
+  data: ResetPasswordRequestBody
+): Promise<{ message: string }> {
+  const { data: response, error } = await client<{ message: string }>(
+    ENDPOINTS.USER.PATCH_RESET_PASSWORD,
+    {
+      method: 'patch',
+      data,
+    }
+  );
+  if (error) {
+    throw new Error('비밀번호 재설정에 실패했습니다', { cause: error });
+  }
+  return response;
+}
+
+export async function updatePassword(
+  data: PatchPasswordRequestBody
+): Promise<{ message: string }> {
+  const { data: response, error } = await client<{ message: string }>(
+    ENDPOINTS.USER.PATCH_PASSWORD,
+    {
+      method: 'patch',
+      data,
+    }
+  );
+  if (error) {
+    throw new Error('비밀번호 업데이트에 실패했습니다.', { cause: error });
+  }
+  return response;
+}

--- a/lib/middlewares/auth.middleware.ts
+++ b/lib/middlewares/auth.middleware.ts
@@ -1,7 +1,8 @@
-import { DEFAULT_TOKEN_OPTIONS } from '@/lib/api/API_CONSTANTS';
-import { checkAccessToken, updateAccessToken } from '@/lib/api/auth';
+import { checkAccessToken } from '@/lib/api/auth';
 import applySetCookie from '@/lib/middlewares/utils';
 import { NextRequest, NextResponse } from 'next/server';
+
+/* eslint-disable consistent-return */
 
 export default async function validateTokenAndSetAuthHeader(
   request: NextRequest
@@ -32,7 +33,7 @@ export default async function validateTokenAndSetAuthHeader(
 
   const nextResponse = NextResponse.next();
 
-  if (nextResponse.headers.get('Authorization')) return nextResponse;
+  // if (nextResponse.headers.get('Authorization')) return nextResponse;
 
   try {
     nextResponse.headers.set('Authorization', `Bearer ${accessToken}`);

--- a/lib/middlewares/auth.middleware.ts
+++ b/lib/middlewares/auth.middleware.ts
@@ -1,0 +1,48 @@
+import { DEFAULT_TOKEN_OPTIONS } from '@/lib/api/API_CONSTANTS';
+import { checkAccessToken, updateAccessToken } from '@/lib/api/auth';
+import applySetCookie from '@/lib/middlewares/utils';
+import { NextRequest, NextResponse } from 'next/server';
+
+export default async function validateTokenAndSetAuthHeader(
+  request: NextRequest
+) {
+  const url = new URL(request.url);
+  const proxyPattern =
+    process.env.NEXT_PUBLIC_PROXY_URL &&
+    url.pathname.startsWith(process.env.NEXT_PUBLIC_PROXY_URL);
+  if (!proxyPattern) return;
+
+  const accessToken = request.cookies.get('accessToken')?.value || null;
+  const refreshToken = request.cookies.get('refreshToken')?.value || null;
+
+  const isValid = accessToken ? await checkAccessToken(accessToken) : false;
+
+  if (!isValid && refreshToken) {
+    // TODO 리프레시토큰으로 엑세스토큰 재설정로직 (수정 예정)
+    // const redirectResponse = NextResponse.redirect(request.url);
+    // const newAccessToken = await updateAccessToken(refreshToken);
+    // redirectResponse.cookies.set(
+    //   'accessToken',
+    //   newAccessToken,
+    //   DEFAULT_TOKEN_OPTIONS
+    // );
+    // applySetCookie(request, redirectResponse);
+    // return redirectResponse;
+  }
+
+  const nextResponse = NextResponse.next();
+
+  if (nextResponse.headers.get('Authorization')) return nextResponse;
+
+  try {
+    nextResponse.headers.set('Authorization', `Bearer ${accessToken}`);
+    applySetCookie(request, nextResponse);
+    return nextResponse;
+  } catch (error) {
+    console.error('토큰 갱신 처리 중 오류 발생:', error);
+    // TODO:
+    // url.pathname = '/';
+    // return NextResponse.redirect(url);
+    // }
+  }
+}

--- a/lib/middlewares/utils.ts
+++ b/lib/middlewares/utils.ts
@@ -1,0 +1,27 @@
+import {
+  RequestCookies,
+  ResponseCookies,
+} from 'next/dist/compiled/@edge-runtime/cookies';
+import { NextRequest, NextResponse } from 'next/server';
+
+export default function applySetCookie(
+  req: NextRequest,
+  res: NextResponse
+): void {
+  const resCookies = new ResponseCookies(res.headers);
+  const newReqHeaders = new Headers(req.headers);
+  const newReqCookies = new RequestCookies(newReqHeaders);
+
+  resCookies.getAll().forEach((cookie) => newReqCookies.set(cookie));
+
+  NextResponse.next({
+    request: { headers: newReqHeaders },
+  }).headers.forEach((value, key) => {
+    if (
+      key === 'x-middleware-override-headers' ||
+      key.startsWith('x-middleware-request-')
+    ) {
+      res.headers.set(key, value);
+    }
+  });
+}

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,7 @@
+import validateTokenAndSetAuthHeader from '@/lib/middlewares/auth.middleware';
+import { NextRequest } from 'next/server';
+
+export async function middleware(request: NextRequest) {
+  const setAuthHeaderResponse = await validateTokenAndSetAuthHeader(request);
+  if (setAuthHeaderResponse) return setAuthHeaderResponse;
+}

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -27,6 +27,36 @@ const nextConfig = {
 
     return config;
   },
+
+  async headers() {
+    return [
+      {
+        source: `${process.env.NEXT_PUBLIC_PROXY_URL}/:path*`,
+        headers: [
+          { key: 'Access-Control-Allow-Credentials', value: 'true' },
+          { key: 'Access-Control-Allow-Origin', value: '*' },
+          {
+            key: 'Access-Control-Allow-Methods',
+            value: 'GET,OPTIONS,PATCH,DELETE,POST,PUT',
+          },
+          {
+            key: 'Access-Control-Allow-Headers',
+            value:
+              'X-CSRF-Token, X-Requested-With, Accept, Accept-Version, Content-Length, Content-MD5, Content-Type, Date, X-Api-Version',
+          },
+        ],
+      },
+    ];
+  },
+
+  async rewrites() {
+    return [
+      {
+        source: `${process.env.NEXT_PUBLIC_PROXY_URL}/:path*`,
+        destination: `${process.env.NEXT_PUBLIC_BASE_URL}/:path*`,
+      },
+    ];
+  },
 };
 
 export default nextConfig;

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@radix-ui/react-slot": "^1.1.0",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.1",
+    "jwt-decode": "^4.0.0",
     "lucide-react": "^0.414.0",
     "next": "14.2.5",
     "next-themes": "^0.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,9 @@ importers:
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
+      jwt-decode:
+        specifier: ^4.0.0
+        version: 4.0.0
       lucide-react:
         specifier: ^0.414.0
         version: 0.414.0(react@18.3.1)
@@ -4389,6 +4392,10 @@ packages:
   jsx-ast-utils@3.3.5:
     resolution: {integrity: sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==}
     engines: {node: '>=4.0'}
+
+  jwt-decode@4.0.0:
+    resolution: {integrity: sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==}
+    engines: {node: '>=18'}
 
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
@@ -11398,6 +11405,8 @@ snapshots:
       array.prototype.flat: 1.3.2
       object.assign: 4.1.5
       object.values: 1.2.0
+
+  jwt-decode@4.0.0: {}
 
   keyv@4.5.4:
     dependencies:

--- a/types/article.d.ts
+++ b/types/article.d.ts
@@ -1,0 +1,20 @@
+declare module '@ccc-types' {
+  export type ArticleTitle = string; // minimum: 1 , maximum: 200
+  export type ArticleWriter = Pick<User, 'nickname' | 'id'>;
+  export type ArticleContent = string; // minimum: 1
+  export type ArticleOrder = 'recent' | 'like';
+
+  export type ArticleDetail = {
+    updatedAt: DateString;
+    createdAt: DateString;
+    likeCount: number;
+    writer: ArticleWriter;
+    image?: UrlType | null;
+    title: ArticleTitle;
+    id: Id;
+    isLiked: boolean | null; // nullable
+    content: ArticleContent;
+  };
+
+  export type Article = Omit<Article, 'isLiked' | 'content'>;
+}

--- a/types/auth.d.ts
+++ b/types/auth.d.ts
@@ -2,11 +2,7 @@ declare module '@ccc-types' {
   // ------------------ OAuth ------------------ //
   export type OAuthToken = string;
   export type AppSecret = string; // 간편 로그인을 위한 비밀 키
-
-  export enum OAuthProvider {
-    GOOGLE = 'GOOGLE',
-    KAKAO = 'KAKAO',
-  }
+  export type OAuthProvider = 'GOOGLE' | 'KAKAO';
 
   export interface OAuthApp {
     createdAt: DateString;

--- a/types/common.d.ts
+++ b/types/common.d.ts
@@ -1,6 +1,15 @@
 declare module '@ccc-types' {
   export type Id = number; // integer($int32), minimum: 1
-  export type UrlType = string;
-  export type DateString = string; // example: "2021-01-01T00:00:00Z"
+  export type UrlType = string; // pattern: ^https?://.+
+  export type DateString = Date | string; // example: "2021-01-01T00:00:00Z" , ISO 8601 날짜-시간 문자열
   export type DateFormatType = 'dotFormat' | 'koreanFullDate' | 'monthAndDay';
+
+  export type OffsetBasedPagination<T> = {
+    totalCount: number; // ($double)
+    list: T[];
+  };
+  export type CursorBasedPagination<T> = {
+    nextCursor: number;
+    list: T[];
+  };
 }

--- a/types/task.d.ts
+++ b/types/task.d.ts
@@ -1,33 +1,34 @@
 declare module '@ccc-types' {
   export type DisplayIndex = number; // integer($int32), minimum: 0
 
-  export enum FrequencyType { // export type FrequencyType = 'DAILY' | 'WEEKLY' | 'MONTHLY' | 'ONCE';
-    DAILY = 'DAILY',
-    WEEKLY = 'WEEKLY',
-    MONTHLY = 'MONTHLY',
-    ONCE = 'ONCE',
-  }
+  export type FrequencyType = 'DAILY' | 'WEEKLY' | 'MONTHLY' | 'ONCE';
 
   export interface Task {
     deletedAt: DateString;
-    recurringId: Id; // number($double)
+    recurringId: Id;
     frequency: FrequencyType | string;
-    userId: Id; // number($double)
+    userId: Id;
     date: DateString;
     doneAt?: DateString | null; // nullable: true
-    description?: string; // NOTE 스웨거문서 미완성으로 인한..
+    description?: string;
     updatedAt: DateString;
     name: string;
-    id: Id; // number($double)
+    id: Id;
   }
 
   export interface GroupTask {
     groupId: Id;
-    displayIndex: number;
-    updateAt: DateString;
+    taskListId: Id;
+    displayIndex?: number;
+    monthDay: number;
+    weekDays: number[];
+    frequencyType: FrequencyType;
+    description?: string;
+    updatedAt: DateString;
     createdAt: DateString;
     name: Nickname;
     id: Id;
-    tasks: string[];
   }
+
+  // tasks: string[]
 }

--- a/types/user.d.ts
+++ b/types/user.d.ts
@@ -2,20 +2,16 @@ declare module '@ccc-types' {
   export type Email = string;
   export type Nickname = string; // 최소 길이 1, 최대 길이 30
   export type Password = string;
-
-  export enum RoleType { // export type RoleType = 'ADMIN' | 'MEMBER';
-    ADMIN = 'ADMIN',
-    MEMBER = 'MEMBER',
-  }
+  export type RoleType = 'ADMIN' | 'MEMBER';
 
   export interface User {
-    teamId: Id; // 필수 문자열
-    image?: UrlType | null; // URL 형식의 문자열, nullable
-    updatedAt: DateString; // 필수 ISO 8601 날짜-시간 문자열
-    createdAt: DateString; // 필수 ISO 8601 날짜-시간 문자열
-    nickname: Nickname; // 필수 문자열, 최소 길이 1, 최대 길이 30
-    email: Email; // NOTE
-    id: Id; // 필수 32비트 정수, 최소값 1
+    teamId: Id;
+    image?: UrlType | null;
+    updatedAt: DateString;
+    createdAt: DateString;
+    nickname: Nickname;
+    email: Email;
+    id: Id;
   }
 
   export interface UserWithGroups extends User {
@@ -23,7 +19,7 @@ declare module '@ccc-types' {
   }
 
   export interface Group {
-    updateAt: DateString;
+    updatedAt: DateString;
     createdAt: DateString;
     image: UrlType;
     name: Nickname;


### PR DESCRIPTION
## ✅ 작업 사항

지금 코워커스 관련 답변들이 달리기 시작한거같은데.... 
일단 오류없는 부분들만 올려놨습니다 (ㅠㅠ 🥹)


## 📸 결과물


axios 같은 역할을하는 HttpClient가 있구요 
(기존 axios랑 거의 비슷하게 작업해서 어렵지는 않으실거같습니다!!)
instance역할을 하는 `@/lib/api/client/client` , `@/lib/api/client/server` 두가지가 있습니다.

요 두개에 대해서 설명하면

기본적으로 
HttpClient내부에서 직렬화, 역직렬화를 자동으로 해주고 있고,
400이상 에러는 따로 CustomError 형식으로 에러를 던져줍니다 (`({message, config, error})` 형식으로, axios와 거의 동일해요)
다른 에러처리는 따로 해주지 않고 있습니다. 
(에러처리 관련해서는 나중에 더 리팩토링이 필요할거 같아요 댓글 환영...🤩 🤩 🤩 )

```javascript
const serverClient = new Client({
  baseURL: process.env.NEXT_PUBLIC_BASE_URL,
  headers: { 'Content-Type': 'application/json' },
  timeout: 5000,
  withCredentials: true,
});
```
이런식으로 instance를 만들 수 있습니다 (axios랑 똑같 져. !?)
fetch로 동작하니까 next app router fetch에서 제공하는 cache나 next {revalidate: false} 도 추가가 가능합니다

기본적으로 instance역할을 하는 파일에서 아래 같은 형식으로 export 하고 있습니다
```
const client = async <T = unknown>(url: string, options: HttpClientConfig) => {
  try {
    const response: T = await clientInstance.request(url, options);
    return { data: response };
  } catch (error) {
    return { error: error as CustomError };
  }
};
export default client;
```

제네릭을 통해서 response data 타입이 지정가능하구요.
{data , error } 형식으로 return값이 생기기때문에 사용할때 try-catch문 없이 사용이 가능합니다

(로딩이나 펜딩관련도 추가하면 좋을거같은데 의견주세요!!)

```javascript
// 로그인에서 사용 예시
export async function login(data: SignInRequestBody): Promise<void> {
  const { data: response, error } = await client<AuthResponse>(
    ENDPOINTS.AUTH.POST_SIGNIN,
    {
      method: 'post',
      data,
    }
  );
  if (error) {
    throw new Error(error.message || '로그인에 실패했습니다', error);
  }
  setTokenAndRedirection(response.accessToken, response.refreshToken);
}
```



서버/클라이언트 플로우를 보면 

서버에서 발생한 요청은 `@/lib/api/client/server`를 거쳐 cookie가 setting되어 요청이 실행되게 됩니다.
클라이언트에서 발생한 요청은 `@/lib/api/client/client` + middleware + proxy 를 거쳐 cookie가 setting되어 요청이 실행되게 됩니다.
( 쿠키를 httpOnly로 지정하기때문에 client측에서 접근이 어려워 미들웨어를 이용했습니다!, 
또한 기본적으로 ` withCredentials: true,`를 지정하고싶고 또 서버측클라이언트측 구분이 잘 될지 모르겠어서... 혹시 몰라 proxy 설정해줬습니다!! cookie담아서 보내도록여)

간단한 흐름은 이정도입니다..
글 가독성이 좀 별로져? 좀 이따가 읽기편하게 더 수정하겠습니다

지적 제안 모두 감사합니다 



## 👩‍💻 공유 포인트 및 논의 사항

- URL env로 빼놨는데요 사용하기 편하게 일단 올렸는데 
그냥 편하게 개발하려면 main에 넣고 아니면 그냥 각자 생성해서 쓰는걸루해요 (브랜치에서 제거해놓겠습니다!!)

- 상수파일 그냥 /lib/api에 넣었어요 (뺄가여?)

- 로딩이나 펜딩관련도 자동으로 처리해주는 뭔가를 만들고싶은데 괜찮으신가요

- 에러처리 관련해서, 에러바운더리 사용하나요? 선호하시는 에러처리 방법있으신가요 공유해주세요 반영해놓겠습니다 
머 네트워크 오류는 retry한다거나 ... 500번대 에러는 따로 다 빼놓는다거나.. 

- 아!! 그리고 auth 관련 함수들은 다 server함수로 만들어놨어요 그게 더 보안에 좋을거같아서 
 

