### PR TITLE
🐛 hotfix: 헤더 fixed를 sticky로 변경 (Jira Ticket : CCC-35)

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -34,7 +34,7 @@ export default function RootLayout({
           enableSystem
           disableTransitionOnChange
         >
-          <nav className="fixed top-0 z-50 flex h-[60px] w-full items-center bg-background-secondary">
+          <nav className="sticky top-0 z-50 flex h-[60px] w-full items-center bg-background-secondary">
             <div className="flex h-full w-full items-center justify-between px-4 py-5 xl:mx-auto xl:w-[1200px] xl:p-0">
               <Link href="/">
                 {/* REVIEW - svgr vs Nextjs Image 태그 */}

--- a/components/landing/LandingTopSection.tsx
+++ b/components/landing/LandingTopSection.tsx
@@ -3,7 +3,7 @@ import Image from 'next/image';
 
 export default function LandingTopSection() {
   return (
-    <section className="mt-[60px] flex h-[calc(100vh-60px)] flex-col items-center">
+    <section className="flex h-[calc(100vh-60px)] flex-col items-center">
       {/* NOTE - 상단 랜딩 이미지 */}
       <div className="absolute -z-50 size-full">
         <Image


### PR DESCRIPTION
## ✅ 작업 사항

fixed를 sticky로 바꾸어 layout과 관련된 페이지에서 margin을 주지 않아도 헤더의 크기만큼 떨어지도록 바꾸었습니다

## 📸 결과물

프리뷰로 대체하겠습니다

## 👩‍💻 공유 포인트 및 논의 사항
