### PR TITLE
🐛 hotfix: 픽스된 히스토리 응답 타입에 따른 로직 수정

### DIFF
--- a/app/(user)/user-history/_components/HistoryItem.tsx
+++ b/app/(user)/user-history/_components/HistoryItem.tsx
@@ -1,12 +1,18 @@
+import { dateFormatter } from '@/lib/utils';
 import CheckIcon from '@/public/icons/user-history/check_icon.svg';
 import { Task } from '@ccc-types';
 
 function HistoryItem({ task }: { task: Task }) {
   return (
-    <div className="flex items-center gap-1 rounded-lg bg-customBackground-secondary px-[14px] py-[10px]">
-      <CheckIcon />
-      <p className="mr-[10px]">
-        <s>{task.name}</s>
+    <div className="flex items-center justify-between rounded-lg bg-customBackground-secondary px-[14px] py-[10px]">
+      <div className="flex gap-1">
+        <CheckIcon />
+        <p className="mr-[10px]">
+          <s>{task.name}</s>
+        </p>
+      </div>
+      <p className="text-customBackground-teritiary">
+        {dateFormatter.toTimeDifference(task.updatedAt)} 완료
       </p>
     </div>
   );

--- a/app/(user)/user-history/_components/HistoryList.tsx
+++ b/app/(user)/user-history/_components/HistoryList.tsx
@@ -1,20 +1,45 @@
-'use client';
-
 import { dateFormatter } from '@/lib/utils';
 import { Task } from '@ccc-types';
 
 import HistoryItem from './HistoryItem';
 
+interface SortedHistoryList {
+  [formattedDate: string]: Task[];
+}
+
 const HistoryList = ({ tasksDone }: { tasksDone: Task[] }) => {
-  const date =
-    tasksDone[0].doneAt &&
-    dateFormatter.toConvertDate(tasksDone[0].doneAt, 'dotFormat');
+  // NOTE - tasksDone 배열 하나에 모든 완료한 일이 합쳐져서 오므로, 날짜에 따라 요소를 분리하고 재배열함
+  const sortedHistoryList: SortedHistoryList = tasksDone.reduce(
+    (newArr, task) => {
+      if (task.doneAt) {
+        // NOTE - 배열의 키로서 날짜 지정
+        const formattedDate = dateFormatter.toConvertDate(
+          new Date(task.doneAt).toISOString().split('T')[0],
+          'dotFormat'
+        );
+        // NOTE - 만약 날짜가 같으면 같은 배열에 넣고, 아니라면 해당 날짜를 기준으로 새로운 배열을 생성
+        return {
+          ...newArr,
+          [formattedDate]: newArr[formattedDate]
+            ? [...newArr[formattedDate], task]
+            : [task],
+        };
+      }
+      // NOTE - 최종적으로 합쳐진 배열들을 newArr로 리턴
+      return newArr;
+    },
+    {} as SortedHistoryList
+  );
 
   return (
     <div className="flex w-full flex-col gap-4">
-      <h2>{date}</h2>
-      {tasksDone.map((task) => (
-        <HistoryItem key={task.id} task={task} />
+      {Object.keys(sortedHistoryList).map((date) => (
+        <>
+          <h2>{date}</h2>
+          {sortedHistoryList[date].map((task) => (
+            <HistoryItem key={task.id} task={task} />
+          ))}
+        </>
       ))}
     </div>
   );

--- a/app/(user)/user-history/page.tsx
+++ b/app/(user)/user-history/page.tsx
@@ -14,14 +14,11 @@ async function HistoryPage() {
 
   return (
     <section
-      className={`center mx-auto w-full ${listData && listData[0].tasksDone.length !== 0 ? '' : 'min-screen'} max-w-[1232px] flex-col gap-6 px-4`}
+      className={`center mx-auto w-full ${listData && listData.tasksDone.length !== 0 ? '' : 'min-screen'} max-w-[1232px] flex-col gap-6 px-4`}
     >
       <h1 className="mr-auto mt-5 text-[20px] font-bold">마이 히스토리</h1>
-      {listData && listData[0].tasksDone.length !== 0 ? (
-        listData.map((task, idx) => (
-          // eslint-disable-next-line react/no-array-index-key
-          <HistoryList key={idx} tasksDone={task.tasksDone} />
-        ))
+      {listData && listData.tasksDone.length !== 0 ? (
+        <HistoryList tasksDone={listData.tasksDone} />
       ) : (
         <div className="mb-[120px] flex h-full items-center">
           <p className="text-[14.8px] font-medium text-text-default">

--- a/lib/api/fetchAPI.ts
+++ b/lib/api/fetchAPI.ts
@@ -33,7 +33,7 @@ async function getUser() {
 }
 
 async function getUserHistory() {
-  const { data, error } = await client<History[]>(ENDPOINTS.USER.GET_HISTORY, {
+  const { data, error } = await client<History>(ENDPOINTS.USER.GET_HISTORY, {
     method: 'get',
   });
   if (error) {

--- a/types/task.d.ts
+++ b/types/task.d.ts
@@ -31,6 +31,7 @@ declare module '@ccc-types' {
   }
 
   export interface Comment {
+    user: Pick<User, 'image' | 'nickname' | 'id'>;
     userId: number;
     taskId: number;
     updatedAt: DateString;
@@ -40,6 +41,7 @@ declare module '@ccc-types' {
   }
 
   export interface Recurring {
+    writerId: number;
     groupId: number;
     taskListId: number;
     monthDay: number;
@@ -53,10 +55,15 @@ declare module '@ccc-types' {
     id: number;
   }
 
+  interface DoneBy {
+    user: Pick<User, 'image' | 'nickname' | 'id'>;
+  }
+
   export interface DetailTask extends Task {
     comments: Comment[];
     recurring: Recurring;
     user: Pick<User, 'image' | 'nickname' | 'id'>;
+    doneBy: DoneBy;
   }
 
   // tasks: string[]


### PR DESCRIPTION
  <!-- PR 제목은 커밋 메세지 컨벤션 형식으로 작성 -->

## ✅ 작업 사항

- 하나의 배열에 모든 값이 담겨옴에 따라 히스토리 리스트 로직을 재구성했습니다.

## 📸 결과물

- 로컬에서 확인해주셔요 ☺️

## 👩‍💻 공유 포인트 및 논의 사항
