### PR TITLE
♻️ refactor: image input 로직 훅으로 분리, api hook에 reset 함수 추가 

### DIFF
--- a/app/(user)/my-account/_components/ProfileSettingsForm.tsx
+++ b/app/(user)/my-account/_components/ProfileSettingsForm.tsx
@@ -4,14 +4,14 @@ import ImageInputUI from '@/components/ui/ImageInputLabel';
 import { Button } from '@/components/ui/button';
 import * as Form from '@/components/ui/form';
 import { Input } from '@/components/ui/input';
+import useImageFile from '@/hooks/useImagePreview';
 import useRequestFunction from '@/hooks/useRequestFunction';
-import uploadImage from '@/lib/api/common';
 import { updateUser } from '@/lib/api/user';
 import { nameSchema } from '@/lib/schema/auth';
 import Profile from '@/public/icons/profile.svg';
 import { User } from '@ccc-types';
 import { zodResolver } from '@hookform/resolvers/zod';
-import { useEffect, useState } from 'react';
+import { useEffect } from 'react';
 import { useForm } from 'react-hook-form';
 import { toast } from 'sonner';
 import { z } from 'zod';
@@ -26,8 +26,6 @@ const formSchema = z.object({
 type ProfileSettingsFormProps = Pick<User, 'image' | 'nickname'>;
 
 const ProfileSettingsForm = ({ image, nickname }: ProfileSettingsFormProps) => {
-  const api = useRequestFunction(updateUser);
-
   const form = useForm<z.infer<typeof formSchema>>({
     resolver: zodResolver(formSchema),
     defaultValues: {
@@ -35,18 +33,17 @@ const ProfileSettingsForm = ({ image, nickname }: ProfileSettingsFormProps) => {
       nickname,
     },
   });
-
-  const [imagePreview, setImagePreview] = useState(image);
+  const currentImage = form.watch('image');
+  const { uploadedImage, imagePreview } = useImageFile(currentImage);
+  const api = useRequestFunction(updateUser);
 
   async function onSubmit(values: z.infer<typeof formSchema>) {
     const updatedProfile: { nickname?: string; image?: string } = {};
-
+    // 데이터 세팅
     if (nickname !== values.nickname) updatedProfile.nickname = values.nickname;
-    if (values.image && values.image !== image) {
-      const { data } = await uploadImage(values.image);
-      updatedProfile.image = data;
+    if (values?.image !== image && typeof uploadedImage === 'string') {
+      updatedProfile.image = uploadedImage;
     }
-
     // 변경사항이 없을 경우 toast
     if (!updatedProfile.image && !updatedProfile.nickname) {
       toast.error('변경된 내용이 없습니다');
@@ -56,29 +53,17 @@ const ProfileSettingsForm = ({ image, nickname }: ProfileSettingsFormProps) => {
     await api.request(updatedProfile);
   }
 
-  const currentImage = form.watch('image');
-
-  // 이미지 프리뷰 설정
-  useEffect(() => {
-    if (!currentImage || typeof currentImage === 'string') return;
-    setImagePreview(URL.createObjectURL(currentImage));
-  }, [currentImage]);
-
   // API 요청 결과에 따른 로직처리
   useEffect(() => {
     if (api.isError) {
       toast.error(api.error?.message || api.error?.info);
+      api.reset();
     }
     if (api.isSuccess) {
       toast.success('변경사항이 저장되었습니다');
+      api.reset();
     }
-  }, [
-    api.isError,
-    api.isSuccess,
-    api.data,
-    api.error?.info,
-    api.error?.message,
-  ]);
+  }, [api, api.isError, api.isSuccess, api.error?.info, api.error?.message]);
 
   return (
     <Form.Form {...form}>

--- a/app/(user)/my-account/_components/ProfileSettingsForm.tsx
+++ b/app/(user)/my-account/_components/ProfileSettingsForm.tsx
@@ -7,7 +7,7 @@ import { Input } from '@/components/ui/input';
 import useImageFile from '@/hooks/useImagePreview';
 import useRequestFunction from '@/hooks/useRequestFunction';
 import { updateUser } from '@/lib/api/user';
-import { nameSchema } from '@/lib/schema/auth';
+import { imageSchema, nameSchema } from '@/lib/schema/auth';
 import Profile from '@/public/icons/profile.svg';
 import { User } from '@ccc-types';
 import { zodResolver } from '@hookform/resolvers/zod';
@@ -17,9 +17,7 @@ import { toast } from 'sonner';
 import { z } from 'zod';
 
 const formSchema = z.object({
-  image: z.custom<File | string>(
-    (v) => v instanceof File || typeof v === 'string'
-  ),
+  image: imageSchema,
   nickname: nameSchema,
 });
 

--- a/components/common/error/Error.tsx
+++ b/components/common/error/Error.tsx
@@ -1,10 +1,10 @@
 import DogLottie from '@/public/animation/dog.json';
-import error from 'next/error';
 
 import { LazyLottie } from '../lottie/LazyLottie';
 import ErrorFallBackButtons from './ErrorButtons';
 
 interface ErrorProps {
+  error?: any;
   title?: string;
   subTitle?: string;
   description: string;
@@ -13,6 +13,7 @@ interface ErrorProps {
 }
 
 const Error = ({
+  error,
   title = '! ERROR',
   subTitle,
   description,
@@ -38,7 +39,7 @@ const Error = ({
             <h2 className="mb-4 text-lg text-text-default">
               개발 모드에서만 보여지는 정보에요
             </h2>
-            <p>{JSON.stringify(error, null, 2)}</p>
+            <p>{error && JSON.stringify(error, null, 2)}</p>
           </div>
         )}
 

--- a/components/common/error/ErrorFallback.tsx
+++ b/components/common/error/ErrorFallback.tsx
@@ -44,7 +44,11 @@ const ErrorFallbackUI = ({ error, onClickRetry }: ErrorBoundaryState) => {
   if (!error) return;
 
   return (
-    <Error description={getErrorMessage(error)} onClickRetry={onClickRetry} />
+    <Error
+      error={error}
+      description={getErrorMessage(error)}
+      onClickRetry={onClickRetry}
+    />
   );
 };
 

--- a/hooks/useImagePreview.ts
+++ b/hooks/useImagePreview.ts
@@ -1,0 +1,44 @@
+'use client';
+
+import uploadImage from '@/lib/api/common';
+import { useEffect, useState } from 'react';
+import { toast } from 'sonner';
+
+const useImageFile = (currentImage?: any) => {
+  const [imagePreview, setImagePreview] = useState<string | undefined>(
+    undefined
+  );
+  const [uploadedImage, setUploadedImage] = useState<string | undefined>(
+    undefined
+  );
+
+  // 이미지 프리뷰 설정
+  useEffect(() => {
+    const uploadData = async () => {
+      if (!currentImage) return;
+
+      if (typeof currentImage === 'string') {
+        setImagePreview(currentImage);
+      } else {
+        const objectURL = URL.createObjectURL(currentImage);
+        setImagePreview(objectURL);
+
+        const { data, error } = await uploadImage(currentImage);
+        if (error) {
+          toast.error(error.message);
+          return;
+        }
+        setUploadedImage(data);
+
+        // Cleanup
+        return () => URL.revokeObjectURL(objectURL);
+      }
+    };
+
+    uploadData();
+  }, [currentImage]);
+
+  return { uploadedImage, imagePreview };
+};
+
+export default useImageFile;

--- a/hooks/useRequestFunction.ts
+++ b/hooks/useRequestFunction.ts
@@ -71,7 +71,7 @@ const useRequestFunction = <T = any>(
         isPending: true,
       }));
 
-      const response = await apiFunction(props);
+      const response = await apiFunction(...props);
 
       if (response?.error) {
         setState({
@@ -80,8 +80,9 @@ const useRequestFunction = <T = any>(
           errorMessage: response.error?.message || 'An error occurred',
           error: response.error,
         });
-        if (showErrorFallBack && !response.error.hasBodyMessage)
+        if (showErrorFallBack && !response.error.hasBodyMessage) {
           showBoundary(response?.error);
+        }
         return { data: null, error: response.error };
       }
       if (!response?.error) {
@@ -96,7 +97,11 @@ const useRequestFunction = <T = any>(
     [apiFunction]
   );
 
-  return { ...state, request };
+  const reset = useCallback(() => {
+    setState(INITIAL_STATE);
+  }, []);
+
+  return { ...state, request, reset };
 };
 
 export default useRequestFunction;


### PR DESCRIPTION
## ✅ 작업 사항

image input 로직을 분리하구 

api 상태변경에 따른 클라이언트 처리를 도와주는 api hook에서 실패요청 -> 실패요청 또는 성공요청 -> 성공요청일경우 
상태가 제대로 업데이트 되지 않는 문제가 있어서 상태를 reset해주는 함수를 추가했습니다
~ ~

## 📸 결과물


## 👩‍💻 공유 포인트 및 논의 사항
